### PR TITLE
Send certificate name derived from `RENEWED_LINEAGE`

### DIFF
--- a/certbot_deploy_hook
+++ b/certbot_deploy_hook
@@ -25,6 +25,7 @@ if [ -z "$DEPLOY_HOOK_URL" ]; then
 fi
 
 CERT=$(sudo cat "${RENEWED_LINEAGE}/cert.pem")
+CERT_NAME=$(basename "${RENEWED_LINEAGE}")
 
 curl \
 --location \
@@ -33,5 +34,6 @@ curl \
 --write-out "\n%{url_effective} -> HTTP %{http_code} (in %{time_total}s)\n" \
 --form user="$DEPLOY_HOOK_USER" \
 --form key="$DEPLOY_HOOK_KEY" \
+--form name="$CERT_NAME" \
 --form certificate="$CERT" \
 "$DEPLOY_HOOK_URL"


### PR DESCRIPTION
Certificates issued using some of the [Let's Encrypt Profiles](https://letsencrypt.org/docs/profiles/) do not contain CN (Common Name). For validation, the SAN (Subject Alternative Names) extension field is used instead, but for management purposes I need a single "main" domain name. The domains in the SAN field are alphabetically sorted, and the "main" domain is not necessarily the first one. So we'll need to receive the "main" domain as well. And coincidentally, that's the directory name. Unless it's changed in the configuration to something wild, of course, which won't happen, hopefully.