### PR TITLE
Check the certificate file exists

### DIFF
--- a/certbot_deploy_hook
+++ b/certbot_deploy_hook
@@ -24,7 +24,13 @@ if [ -z "$DEPLOY_HOOK_URL" ]; then
 	exit 2
 fi
 
-CERT=$(sudo cat "${RENEWED_LINEAGE}/cert.pem")
+CERT_FILENAME="${RENEWED_LINEAGE}/cert.pem"
+if [ ! -f "$CERT_FILENAME" ]; then
+	echo "File does not exist $CERT_FILENAME"
+	exit 3
+fi
+
+CERT=$(sudo cat "$CERT_FILENAME")
 CERT_NAME=$(basename "${RENEWED_LINEAGE}")
 
 curl \


### PR DESCRIPTION
I've done a typo once in the RENEWED_LINEAGE variable in the command line when logging a newly added cert (as opposed to automatically logged renewals), and got HTTP 500. This should prevent the 500 errors, which should not happen in the first place, see https://github.com/spaze/michalspacek.cz/pull/588